### PR TITLE
fix: replace escaped newline when importing private key

### DIFF
--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -24,6 +24,7 @@ function pemToArrayBuffer(pem: string) {
   const base64 = pem
     .replace(/-----BEGIN PRIVATE KEY-----/, '')
     .replace(/-----END PRIVATE KEY-----/, '')
+    .replace(/\\n/g, '')
     .replace(/\s+/g, '');
 
   const binary = atob(base64);


### PR DESCRIPTION
## Overview

Closes #9 

This pull request fixes private key import behavior by replacing escaped newline sequences with empty string, since the string may contain it.