### PR TITLE
chore: substract time by 2 hours

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -3,7 +3,7 @@ name: Send daily bug report to GLChat channel
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 1 * * *"
 
 jobs:
   report:


### PR DESCRIPTION
## Overview

Since daily bug report is always late by 2 hours from intended time, why don't we substract 2 hours here?