### PR TITLE
feat: add more repositories

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -14,9 +14,15 @@ export const JWT = {
   Grant: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
 };
 
-export const GLChatMetadata = {
-  owner: 'GDP-ADMIN',
-  repo: 'glchat',
+export const RepositoryOwner = 'GDP-ADMIN';
+export const Repositories: Record<string, string> = {
+  glchat: 'GLChat',
+  'smart-search': 'Smart Search',
+  'ai-agent-platform': 'Agent',
+  'gl-connectors': 'GLConnectors',
+  'gl-langflow': 'LangFlow',
+  'glchat-mobile-app': 'GLChat Native',
+  meemo: 'Meemo',
 };
 
 export const DefaultChunkSize = 5;

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -38,9 +38,9 @@ describe('getCurrentlyActiveBugs', () => {
     );
 
     const spy = vi.spyOn(console, 'error').mockImplementationOnce(() => {});
-    const result = await getCurrentlyActiveBugs('tokenA');
+    const result = await getCurrentlyActiveBugs('glchat', 'tokenA');
 
-    expect(result).toEqual([]);
+    expect(result).toBeUndefined();
     expect(spy).toHaveBeenCalledOnce();
   });
 
@@ -76,7 +76,7 @@ describe('getCurrentlyActiveBugs', () => {
       }),
     );
 
-    const result = await getCurrentlyActiveBugs('tokenA');
+    const result = await getCurrentlyActiveBugs('glchat', 'tokenA');
 
     expect(result).toEqual([
       {
@@ -108,7 +108,7 @@ describe('getCurrentlyActiveBugs', () => {
       }),
     );
 
-    const result = await getCurrentlyActiveBugs('tokenA');
+    const result = await getCurrentlyActiveBugs('glchat', 'tokenA');
 
     expect(result).toEqual([
       {
@@ -153,7 +153,7 @@ describe('getCurrentlyActiveBugs', () => {
       }),
     );
 
-    const result = await getCurrentlyActiveBugs('tokenA');
+    const result = await getCurrentlyActiveBugs('glchat', 'tokenA');
 
     expect(result).toEqual([
       {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,5 +1,4 @@
-import { GLChatMetadata } from '@/const';
-
+import { RepositoryOwner } from '@/const';
 import type { Bug } from '@/types';
 
 interface GithubUser {
@@ -28,34 +27,41 @@ interface GithubIssue {
  *
  * An issue is classified as a bug when it has `bug` label on them (case-sensitive).
  *
- * @param {string} githubToken GitHub access token
+ * @param {string} repo Repository name
+ * @param {string} token GitHub access token
  * @returns {Promise<Bug[]>} Resolves into a list of bugs. Will return empty
  * array if GitHub API call failed.
  */
 export async function getCurrentlyActiveBugs(
-  githubToken: string,
+  repo: string,
+  token: string,
 ): Promise<Bug[]> {
   const params = new URLSearchParams();
   params.append('labels', 'bug');
   params.append('state', 'open');
 
   const url = new URL(
-    `/repos/${GLChatMetadata.owner}/${GLChatMetadata.repo}/issues`,
+    `/repos/${RepositoryOwner}/${repo}/issues`,
     'https://api.github.com',
   );
   url.search = params.toString();
+
+  console.log(url.toString());
 
   const response = await fetch(url, {
     method: 'GET',
     headers: {
       Accept: 'application/vnd.github+json',
-      Authorization: `Bearer ${githubToken}`,
+      Authorization: `Bearer ${token}`,
       'X-GitHub-Api-Version': '2022-11-28',
       'User-Agent': 'bugle',
     },
   });
 
   if (!response.ok) {
+    const body = await response.json();
+
+    console.log(body);
     console.error(
       `Failed to fetch issues from GitHub. Response returned ${response.status}`,
     );
@@ -85,7 +91,7 @@ export async function getCurrentlyActiveBugs(
           const userResponse = await fetch(user.url, {
             headers: {
               Accept: 'application/vnd.github+json',
-              Authorization: `Bearer ${githubToken}`,
+              Authorization: `Bearer ${token}`,
               'X-GitHub-Api-Version': '2022-11-28',
               'User-Agent': 'bugle',
             },

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -29,13 +29,13 @@ interface GithubIssue {
  *
  * @param {string} repo Repository name
  * @param {string} token GitHub access token
- * @returns {Promise<Bug[]>} Resolves into a list of bugs. Will return empty
- * array if GitHub API call failed.
+ * @returns {Promise<Bug[] | undefined>} Resolves into a list of bugs. Will return undefined
+ * if GitHub API call failed.
  */
 export async function getCurrentlyActiveBugs(
   repo: string,
   token: string,
-): Promise<Bug[]> {
+): Promise<Bug[] | undefined> {
   const params = new URLSearchParams();
   params.append('labels', 'bug');
   params.append('state', 'open');
@@ -45,8 +45,6 @@ export async function getCurrentlyActiveBugs(
     'https://api.github.com',
   );
   url.search = params.toString();
-
-  console.log(url.toString());
 
   const response = await fetch(url, {
     method: 'GET',
@@ -59,14 +57,11 @@ export async function getCurrentlyActiveBugs(
   });
 
   if (!response.ok) {
-    const body = await response.json();
-
-    console.log(body);
     console.error(
       `Failed to fetch issues from GitHub. Response returned ${response.status}`,
     );
 
-    return [];
+    return undefined;
   }
 
   const bugs = (await response.json()) as GithubIssue[];

--- a/src/scheduler/daily.ts
+++ b/src/scheduler/daily.ts
@@ -1,4 +1,4 @@
-import { IssueReporter } from '@/const';
+import { IssueReporter, Repositories } from '@/const';
 import { chunkArray } from '@/lib/array';
 import { formatDate } from '@/lib/date';
 import { getCurrentlyActiveBugs } from '@/lib/github';
@@ -75,156 +75,157 @@ export async function sendDailyBugReminder() {
     googleToken,
   );
 
-  const bugs = await getCurrentlyActiveBugs(env.GH_TOKEN);
-  const text = `*🐛 GLChat Active Bug List*
+  for (const [repo, label] of Object.entries(Repositories)) {
+    const bugs = await getCurrentlyActiveBugs(repo, env.GH_TOKEN);
+    const text = `*🐛 ${label} Active Bug List*
 
-There are *${bugs.length}* of <https://github.com/GDP-ADMIN/glchat/issues|currently active bugs in GLChat> per *${formatDate(today)}*${bugs.length > 0 ? '.' : ' 🎉'}
-${
-  bugs.length
-    ? `
-✅ *Things to do as when assigned to bug(s):*
+  There are *${bugs.length}* of <https://github.com/GDP-ADMIN/${repo}/issues|currently active bugs in ${label}> per *${formatDate(today)}*${bugs.length > 0 ? '.' : ' 🎉'}
+  ${
+    bugs.length
+      ? `
+  ✅ *Things to do as when assigned to bug(s):*
 
-- Investigate the issue that you've been assigned to.
-- Provide a status update in the issue page.
-- If you can't provide a status update to the issue, please state the reason in this thread.
-`
-    : ''
-}
-🧑 *Today's Bug PIC:*
+  - Investigate the issue that you've been assigned to.
+  - Provide a status update in the issue page.
+  - If you can't provide a status update to the issue, please state the reason in this thread.
+  `
+      : ''
+  }
+  🧑 *Today's Bug PIC:*
 
-${dailyBugPic ? `<${dailyBugPic}>` : '-'}`;
+  ${dailyBugPic ? `<${dailyBugPic}>` : '-'}`;
 
-  const threadStarter = await fetch(
-    `https://chat.googleapis.com/v1/spaces/${env.DAILY_GOOGLE_SPACE}/messages`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${googleToken}`,
-        'Content-Type': 'application/json',
+    const threadStarter = await fetch(
+      `https://chat.googleapis.com/v1/spaces/${env.DAILY_GOOGLE_SPACE}/messages`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${googleToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          text,
+        }),
       },
-      body: JSON.stringify({
-        text,
-      }),
-    },
-  );
-
-  const { thread } = (await threadStarter.json()) as {
-    thread: { name: string };
-  };
-
-  const threadId = thread.name;
-  const chunkedBugs = [...chunkArray(bugs)];
-
-  for (const chunk of chunkedBugs) {
-    const issues = await resolveAssignees(
-      chunk,
-      env.DAILY_GOOGLE_SPACE,
-      googleToken,
     );
 
-    await Promise.all(
-      issues.map(async (issue) => {
-        const meta = extractTitleMetadata(issue.title);
+    const { thread } = (await threadStarter.json()) as {
+      thread: { name: string };
+    };
 
-        if (issue.reporter === IssueReporter.Sentry) {
-          // use the original title
-          meta.title = issue.title;
-          meta.source = 'Sentry';
-          meta.type = 'Automated Sentry Report';
-        }
+    const threadId = thread.name;
+    const chunkedBugs = [...chunkArray(bugs)];
 
-        const issueAge = Math.round(
-          (today.getTime() - new Date(issue.created_at ?? '').getTime()) /
-            (1_000 * 60 * 60 * 24),
-        );
+    for (const chunk of chunkedBugs) {
+      const issues = await resolveAssignees(
+        chunk,
+        env.DAILY_GOOGLE_SPACE,
+        googleToken,
+      );
 
-        const picDisplay = issue.assignees.filter(Boolean).length
-          ? `cc: ${issue.assignees.map((a) => (a.startsWith('users/') ? `<${a}>` : `\`${a}\``)).join(' ')}`
-          : '⚠️ _Unassigned_';
+      await Promise.all(
+        issues.map(async (issue) => {
+          const meta = extractTitleMetadata(issue.title);
 
-        await fetch(
-          `https://chat.googleapis.com/v1/spaces/${env.DAILY_GOOGLE_SPACE}/messages?messageReplyOption=REPLY_MESSAGE_OR_FAIL`,
-          {
-            method: 'POST',
-            headers: {
-              Authorization: `Bearer ${googleToken}`,
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              text: picDisplay,
-              cardsV2: [
-                {
-                  cardId: `card-issue-${issue.number}`,
-                  card: {
-                    header: {
-                      title: meta.title,
-                      subtitle: `#${issue.number}`,
-                    },
-                    sections: [
-                      {
-                        collapsible: true,
-                        widgets: [
-                          {
-                            decoratedText: {
-                              topLabel: 'URL',
-                              startIcon: {
-                                knownIcon: 'EMAIL',
-                              },
-                              text: `<a href="${issue.url}">${issue.url}</a>`,
-                            },
-                          },
-                          {
-                            decoratedText: {
-                              topLabel: 'Source',
-                              startIcon: {
-                                knownIcon: 'MULTIPLE_PEOPLE',
-                              },
-                              text: meta.source,
-                            },
-                          },
-                          meta.type
-                            ? {
-                                decoratedText: {
-                                  topLabel: 'Type',
-                                  startIcon: {
-                                    knownIcon: 'DESCRIPTION',
-                                  },
-                                  text: meta.type,
-                                },
-                              }
-                            : undefined,
-                          {
-                            decoratedText: {
-                              topLabel: 'Created At',
-                              startIcon: {
-                                knownIcon: 'INVITE',
-                              },
-                              text: `${formatDate(issue.created_at, { weekday: undefined })}`,
-                            },
-                          },
-                          {
-                            decoratedText: {
-                              topLabel: 'Age',
-                              startIcon: {
-                                knownIcon: 'CLOCK',
-                              },
-                              text: `${issueAge} day(s)`,
-                            },
-                          },
-                        ].filter(Boolean),
-                      },
-                    ],
-                  },
-                },
-              ],
-              thread: {
-                name: threadId,
+          if (issue.reporter === IssueReporter.Sentry) {
+            meta.title = issue.title;
+            meta.source = 'Sentry';
+            meta.type = 'Automated Sentry Report';
+          }
+
+          const issueAge = Math.round(
+            (today.getTime() - new Date(issue.created_at ?? '').getTime()) /
+              (1_000 * 60 * 60 * 24),
+          );
+
+          const picDisplay = issue.assignees.filter(Boolean).length
+            ? `cc: ${issue.assignees.map((a) => (a.startsWith('users/') ? `<${a}>` : `\`${a}\``)).join(' ')}`
+            : '⚠️ _Unassigned_';
+
+          await fetch(
+            `https://chat.googleapis.com/v1/spaces/${env.DAILY_GOOGLE_SPACE}/messages?messageReplyOption=REPLY_MESSAGE_OR_FAIL`,
+            {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${googleToken}`,
+                'Content-Type': 'application/json',
               },
-            }),
-          },
-        );
-      }),
-    );
+              body: JSON.stringify({
+                text: picDisplay,
+                cardsV2: [
+                  {
+                    cardId: `card-issue-${issue.number}`,
+                    card: {
+                      header: {
+                        title: meta.title,
+                        subtitle: `#${issue.number}`,
+                      },
+                      sections: [
+                        {
+                          collapsible: true,
+                          widgets: [
+                            {
+                              decoratedText: {
+                                topLabel: 'URL',
+                                startIcon: {
+                                  knownIcon: 'EMAIL',
+                                },
+                                text: `<a href="${issue.url}">${issue.url}</a>`,
+                              },
+                            },
+                            {
+                              decoratedText: {
+                                topLabel: 'Source',
+                                startIcon: {
+                                  knownIcon: 'MULTIPLE_PEOPLE',
+                                },
+                                text: meta.source,
+                              },
+                            },
+                            meta.type
+                              ? {
+                                  decoratedText: {
+                                    topLabel: 'Type',
+                                    startIcon: {
+                                      knownIcon: 'DESCRIPTION',
+                                    },
+                                    text: meta.type,
+                                  },
+                                }
+                              : undefined,
+                            {
+                              decoratedText: {
+                                topLabel: 'Created At',
+                                startIcon: {
+                                  knownIcon: 'INVITE',
+                                },
+                                text: `${formatDate(issue.created_at, { weekday: undefined })}`,
+                              },
+                            },
+                            {
+                              decoratedText: {
+                                topLabel: 'Age',
+                                startIcon: {
+                                  knownIcon: 'CLOCK',
+                                },
+                                text: `${issueAge} day(s)`,
+                              },
+                            },
+                          ].filter(Boolean),
+                        },
+                      ],
+                    },
+                  },
+                ],
+                thread: {
+                  name: threadId,
+                },
+              }),
+            },
+          );
+        }),
+      );
+    }
   }
 }
 

--- a/src/scheduler/daily.ts
+++ b/src/scheduler/daily.ts
@@ -77,6 +77,10 @@ export async function sendDailyBugReminder() {
 
   for (const [repo, label] of Object.entries(Repositories)) {
     const bugs = await getCurrentlyActiveBugs(repo, env.GH_TOKEN);
+    if (!bugs) {
+      continue;
+    }
+
     const text = `*🐛 ${label} Active Bug List*
 
   There are *${bugs.length}* of <https://github.com/GDP-ADMIN/${repo}/issues|currently active bugs in ${label}> per *${formatDate(today)}*${bugs.length > 0 ? '.' : ' 🎉'}

--- a/src/scheduler/daily.ts
+++ b/src/scheduler/daily.ts
@@ -75,32 +75,89 @@ export async function sendDailyBugReminder() {
     googleToken,
   );
 
-  for (const [repo, label] of Object.entries(Repositories)) {
-    const bugs = await getCurrentlyActiveBugs(repo, env.GH_TOKEN);
-    if (!bugs) {
+  const rawBugs = await Promise.all(
+    Object.entries(Repositories).map(
+      async ([repo, label]) =>
+        [label, await getCurrentlyActiveBugs(repo, env.GH_TOKEN)] as [
+          string,
+          Bug[] | undefined,
+        ],
+    ),
+  );
+
+  const bugs = rawBugs.reduce(
+    (acc, curr) => {
+      if (!curr[1]) {
+        return acc;
+      }
+
+      acc[curr[0]] = curr[1];
+
+      return acc;
+    },
+    {} as Record<string, Bug[]>,
+  );
+  const bugCount = Object.values(bugs).reduce((acc, curr) => {
+    acc.push(...curr);
+
+    return acc;
+  }).length;
+
+  const text = `*🐛 GLChat Ecosystem Active Bug List*
+
+There are *${bugCount}* of active bugs in GLChat ecosystem per *${formatDate(today)}*${bugCount > 0 ? ':' : ' 🎉'}
+${
+  bugCount
+    ? `
+${Object.entries(bugs)
+  .map(
+    ([label, repo]) =>
+      `- *${label}*, ${repo.length} ${repo.length === 1 ? 'bug' : 'bugs'}`,
+  )
+  .join('\n')}`
+    : ''
+}
+${
+  bugCount
+    ? `
+✅ *Things to do as when assigned to bug(s):*
+
+- Investigate the issue that you've been assigned to.
+- Provide a status update in the issue page.
+- If you can't provide a status update to the issue, please state the reason in this thread.
+`
+    : ''
+}
+🧑 *Today's Bug PIC:*
+
+${dailyBugPic ? `<${dailyBugPic}>` : '-'}`;
+
+  const threadStarter = await fetch(
+    `https://chat.googleapis.com/v1/spaces/${env.DAILY_GOOGLE_SPACE}/messages`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${googleToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        text,
+      }),
+    },
+  );
+
+  const { thread } = (await threadStarter.json()) as {
+    thread: { name: string };
+  };
+  const threadId = thread.name;
+
+  for (const [label, bugList] of Object.entries(bugs)) {
+    if (bugList.length === 0) {
       continue;
     }
 
-    const text = `*🐛 ${label} Active Bug List*
-
-  There are *${bugs.length}* of <https://github.com/GDP-ADMIN/${repo}/issues|currently active bugs in ${label}> per *${formatDate(today)}*${bugs.length > 0 ? '.' : ' 🎉'}
-  ${
-    bugs.length
-      ? `
-  ✅ *Things to do as when assigned to bug(s):*
-
-  - Investigate the issue that you've been assigned to.
-  - Provide a status update in the issue page.
-  - If you can't provide a status update to the issue, please state the reason in this thread.
-  `
-      : ''
-  }
-  🧑 *Today's Bug PIC:*
-
-  ${dailyBugPic ? `<${dailyBugPic}>` : '-'}`;
-
-    const threadStarter = await fetch(
-      `https://chat.googleapis.com/v1/spaces/${env.DAILY_GOOGLE_SPACE}/messages`,
+    await fetch(
+      `https://chat.googleapis.com/v1/spaces/${env.DAILY_GOOGLE_SPACE}/messages?messageReplyOption=REPLY_MESSAGE_OR_FAIL`,
       {
         method: 'POST',
         headers: {
@@ -108,128 +165,122 @@ export async function sendDailyBugReminder() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          text,
+          text: `🐛 _List of bugs for ${label}_`,
+          thread: {
+            name: threadId,
+          },
         }),
       },
     );
 
-    const { thread } = (await threadStarter.json()) as {
-      thread: { name: string };
-    };
+    const issues = await resolveAssignees(
+      bugList,
+      env.DAILY_GOOGLE_SPACE,
+      googleToken,
+    );
 
-    const threadId = thread.name;
-    const chunkedBugs = [...chunkArray(bugs)];
+    await Promise.all(
+      issues.map(async (issue) => {
+        const meta = extractTitleMetadata(issue.title);
 
-    for (const chunk of chunkedBugs) {
-      const issues = await resolveAssignees(
-        chunk,
-        env.DAILY_GOOGLE_SPACE,
-        googleToken,
-      );
+        if (issue.reporter === IssueReporter.Sentry) {
+          meta.title = issue.title;
+          meta.source = 'Sentry';
+          meta.type = 'Automated Sentry Report';
+        }
 
-      await Promise.all(
-        issues.map(async (issue) => {
-          const meta = extractTitleMetadata(issue.title);
+        const issueAge = Math.round(
+          (today.getTime() - new Date(issue.created_at ?? '').getTime()) /
+            (1_000 * 60 * 60 * 24),
+        );
 
-          if (issue.reporter === IssueReporter.Sentry) {
-            meta.title = issue.title;
-            meta.source = 'Sentry';
-            meta.type = 'Automated Sentry Report';
-          }
+        const picDisplay = issue.assignees.filter(Boolean).length
+          ? `cc: ${issue.assignees.map((a) => (a.startsWith('users/') ? `<${a}>` : `\`${a}\``)).join(' ')}`
+          : '⚠️ _Unassigned_';
 
-          const issueAge = Math.round(
-            (today.getTime() - new Date(issue.created_at ?? '').getTime()) /
-              (1_000 * 60 * 60 * 24),
-          );
-
-          const picDisplay = issue.assignees.filter(Boolean).length
-            ? `cc: ${issue.assignees.map((a) => (a.startsWith('users/') ? `<${a}>` : `\`${a}\``)).join(' ')}`
-            : '⚠️ _Unassigned_';
-
-          await fetch(
-            `https://chat.googleapis.com/v1/spaces/${env.DAILY_GOOGLE_SPACE}/messages?messageReplyOption=REPLY_MESSAGE_OR_FAIL`,
-            {
-              method: 'POST',
-              headers: {
-                Authorization: `Bearer ${googleToken}`,
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify({
-                text: picDisplay,
-                cardsV2: [
-                  {
-                    cardId: `card-issue-${issue.number}`,
-                    card: {
-                      header: {
-                        title: meta.title,
-                        subtitle: `#${issue.number}`,
-                      },
-                      sections: [
-                        {
-                          collapsible: true,
-                          widgets: [
-                            {
-                              decoratedText: {
-                                topLabel: 'URL',
-                                startIcon: {
-                                  knownIcon: 'EMAIL',
-                                },
-                                text: `<a href="${issue.url}">${issue.url}</a>`,
-                              },
-                            },
-                            {
-                              decoratedText: {
-                                topLabel: 'Source',
-                                startIcon: {
-                                  knownIcon: 'MULTIPLE_PEOPLE',
-                                },
-                                text: meta.source,
-                              },
-                            },
-                            meta.type
-                              ? {
-                                  decoratedText: {
-                                    topLabel: 'Type',
-                                    startIcon: {
-                                      knownIcon: 'DESCRIPTION',
-                                    },
-                                    text: meta.type,
-                                  },
-                                }
-                              : undefined,
-                            {
-                              decoratedText: {
-                                topLabel: 'Created At',
-                                startIcon: {
-                                  knownIcon: 'INVITE',
-                                },
-                                text: `${formatDate(issue.created_at, { weekday: undefined })}`,
-                              },
-                            },
-                            {
-                              decoratedText: {
-                                topLabel: 'Age',
-                                startIcon: {
-                                  knownIcon: 'CLOCK',
-                                },
-                                text: `${issueAge} day(s)`,
-                              },
-                            },
-                          ].filter(Boolean),
-                        },
-                      ],
-                    },
-                  },
-                ],
-                thread: {
-                  name: threadId,
-                },
-              }),
+        await fetch(
+          `https://chat.googleapis.com/v1/spaces/${env.DAILY_GOOGLE_SPACE}/messages?messageReplyOption=REPLY_MESSAGE_OR_FAIL`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${googleToken}`,
+              'Content-Type': 'application/json',
             },
-          );
-        }),
-      );
-    }
+            body: JSON.stringify({
+              text: picDisplay,
+              cardsV2: [
+                {
+                  cardId: `card-issue-${issue.number}`,
+                  card: {
+                    header: {
+                      title: meta.title,
+                      subtitle: `#${issue.number}`,
+                    },
+                    sections: [
+                      {
+                        collapsible: true,
+                        widgets: [
+                          {
+                            decoratedText: {
+                              topLabel: 'URL',
+                              startIcon: {
+                                knownIcon: 'EMAIL',
+                              },
+                              text: `<a href="${issue.url}">${issue.url}</a>`,
+                            },
+                          },
+                          {
+                            decoratedText: {
+                              topLabel: 'Source',
+                              startIcon: {
+                                knownIcon: 'MULTIPLE_PEOPLE',
+                              },
+                              text: meta.source,
+                            },
+                          },
+                          meta.type
+                            ? {
+                                decoratedText: {
+                                  topLabel: 'Type',
+                                  startIcon: {
+                                    knownIcon: 'DESCRIPTION',
+                                  },
+                                  text: meta.type,
+                                },
+                              }
+                            : undefined,
+                          {
+                            decoratedText: {
+                              topLabel: 'Created At',
+                              startIcon: {
+                                knownIcon: 'INVITE',
+                              },
+                              text: `${formatDate(issue.created_at, { weekday: undefined })}`,
+                            },
+                          },
+                          {
+                            decoratedText: {
+                              topLabel: 'Age',
+                              startIcon: {
+                                knownIcon: 'CLOCK',
+                              },
+                              text: `${issueAge} day(s)`,
+                            },
+                          },
+                        ].filter(Boolean),
+                      },
+                    ],
+                  },
+                },
+              ],
+              thread: {
+                name: threadId,
+              },
+            }),
+          },
+        );
+      }),
+    );
   }
 }
 


### PR DESCRIPTION
## Overview

This pull request adds more repositories to list of reporting, such as

1. Smart Search
2. LangFlow
3. Native
4. Agent
5. etc

This pull request also changes how the GitHub API behaves when encountering non-200 response as it now returns `undefined` instead of an empty array. The main reason for this change is to differentiate no-access error vs actually no issues.