### PR TITLE
fix: add whitespace check for title type extraction

### DIFF
--- a/src/lib/string.test.ts
+++ b/src/lib/string.test.ts
@@ -54,4 +54,42 @@ describe('extractTitleMetadata', () => {
     expect(result.source).toBe('AVA Feedback');
     expect(result.type).toBe('Prompt / result issue');
   });
+
+  it('should not separate non-dash in the title', () => {
+    const title = 'User is Half-Stuck on Guest Mode after Fresh Install';
+
+    const result = extractTitleMetadata(title);
+
+    expect(result.title).toBe(
+      'User is Half-Stuck on Guest Mode after Fresh Install',
+    );
+    expect(result.source).toBe('Manual Report');
+    expect(result.type).toBeUndefined();
+  });
+
+  it('should not separate non-dash in the title, with custom source', () => {
+    const title =
+      '[GLoria Feedback] User is Half-Stuck on Guest Mode after Fresh Install';
+
+    const result = extractTitleMetadata(title);
+
+    expect(result.title).toBe(
+      'User is Half-Stuck on Guest Mode after Fresh Install',
+    );
+    expect(result.source).toBe('GLoria Feedback');
+    expect(result.type).toBeUndefined();
+  });
+
+  it('should not confuse dash that separate type with actual text, with custom source', () => {
+    const title =
+      '[GLoria Feedback] User Feed-back - User is Half-Stuck on Guest Mode after Fresh Install';
+
+    const result = extractTitleMetadata(title);
+
+    expect(result.title).toBe(
+      'User is Half-Stuck on Guest Mode after Fresh Install',
+    );
+    expect(result.source).toBe('GLoria Feedback');
+    expect(result.type).toBe('User Feed-back');
+  });
 });

--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -9,7 +9,7 @@ import type { IssueMetadata } from '@/types';
  */
 export function extractTitleMetadata(title: string): IssueMetadata {
   const metadata: IssueMetadata = {
-    title,
+    title: title.trim(),
     source: 'Manual Report',
   };
   const source = metadata.title.match(/^\[(.+?)\]/);
@@ -22,7 +22,7 @@ export function extractTitleMetadata(title: string): IssueMetadata {
     metadata.title = metadata.title.slice(1).trim();
   }
 
-  const type = metadata.title.match(/^(.+?)-/);
+  const type = metadata.title.match(/^(.+?)\s+-/);
   if (type) {
     metadata.type = type[1].trim();
     metadata.title = metadata.title.replace(type[0], '').slice(1).trim();


### PR DESCRIPTION
## Overview

This pull request fixes title extraction function that may confuse `type` when you have hyphen on the title. It fixes it by adding extra whitespace check when trying to extract `type`, since people don't normally separate hypen by whitespaces.

### Examples

`User is Half-Stuck on Guest Mode after Fresh Install` won't be separated as 

```json
{
  "type": 'User is Half',
  "title": 'Stuck on Guest Mode after Fresh Install` won't be separated as'
}
```

anymore, since the hyphen is not whitespace-separated.
